### PR TITLE
sync maps with a svelte store

### DIFF
--- a/src/stores.js
+++ b/src/stores.js
@@ -1,0 +1,4 @@
+// https://svelte.dev/tutorial/writable-stores
+import { writable } from "svelte/store";
+
+export const storeExtent = writable(false);


### PR DESCRIPTION
This solution is not perfect (does not handle rotations, does not update maps when you check on/off the checkbox), but meant to be more as an example/POC of how you might sync the maps with [svelte stores](https://svelte.dev/tutorial/writable-stores).