### PR TITLE
extent and rotation syncing with stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2127,9 +2127,9 @@
       }
     },
     "svelte": {
-      "version": "3.16.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.16.7.tgz",
-      "integrity": "sha512-egrva1UklB1n7KAv179IhDpQzMGAvubJUlOQ9PitmmZmAfrCUEgrQnx2vPxn2s+mGV3aYegXvJ/yQ35N2SfnYQ==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.17.1.tgz",
+      "integrity": "sha512-IjX6agpbu01VHBaL/12oFem+ufPRyZNLkg4ay7lJl7IbUB/er90kdIsWCNZX44XaniSEhG/0Hja4GsrtufTwCw==",
       "dev": true
     },
     "terser": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "rollup-plugin-livereload": "^1.0.0",
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.2",
-    "svelte": "^3.0.0"
+    "svelte": "^3.17.1"
   },
   "dependencies": {
     "esri-loader": "^2.13.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1,18 +1,20 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
 
-	<title>Esri Svelte Example: Explore Esri's Basemaps</title>
+  <title>Esri Svelte Example: Explore Esri's Basemaps</title>
 
-	<link rel="icon" type="image/png" href="/favicon.png">
-	<link rel="stylesheet" href="/global.css">
-	<link rel="stylesheet" href="/build/bundle.css">
+  <link rel="icon" type="image/png" href="/favicon.png">
+  <link rel="stylesheet" href="/global.css">
+  <link rel="stylesheet" href="/build/bundle.css">
 
-	<script defer src="/build/bundle.js"></script>
+  <script defer src="/build/bundle.js"></script>
 </head>
 
 <body>
 </body>
+
 </html>

--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1">
 
-	<title>Svelte app</title>
+	<title>Esri Svelte Example: Explore Esri's Basemaps</title>
 
 	<link rel="icon" type="image/png" href="/favicon.png">
 	<link rel="stylesheet" href="/global.css">

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,17 +1,14 @@
 <script>
-	import Card from './Card.svelte';
+  import Card from './Card.svelte';
+  import SyncExtentsCheckbox from './SyncExtentsCheckbox.svelte'
 
+  // a handful of configurable props defined in main.js
 	export let title;
   export let subtitle;
 
   // use the same center and scale for each <EsriMapView>
-  export let demoCenter = [-59.5, -51.85];
-  export let demoScale = 4622324;
-
-  // optionally sync MapView extents by binding a Boolean value to a checkbox
-  // and passing the value down to the <EsriMapView> children components
-  let syncExtents = true;
-  const syncExtentsLabel = 'Sync Extent and Rotation?';
+  export let demoCenter;
+  export let demoScale;
 
   // use a unique raster basemap for each <EsriMapView>
 	const rasterBasemaps = [
@@ -45,7 +42,8 @@
   <h2>{subtitle}</h2>
 
   <p class="project-info">
-    Built by <a href="https://twitter.com/JWasilGeo" class="author">Jacob Wasilkowski</a> with
+    Built by <a href="https://twitter.com/JWasilGeo" class="author">Jacob Wasilkowski</a> and
+    <a href="https://github.com/jwasilgeo/esri-svelte-basemaps-example/graphs/contributors" target="_blank" class="author">friends</a> with
     <a href="https://svelte.dev" target="_blank">Svelte</a> and
     <a href="https://github.com/esri/esri-loader" target="_blank">esri-loader</a>.
   </p>
@@ -78,27 +76,23 @@
 
   <hr>
 
-  <label>
-    <input type="checkbox" bind:checked={syncExtents}/> {syncExtentsLabel}
-  </label>
+  <SyncExtentsCheckbox />
 
 	<h3 id="raster-basemaps">Raster Tile Basemaps</h3>
 
   <!-- a list of <Card> components containing one <EsriMapView> component -->
 	{#each rasterBasemaps as basemap}
-    <Card basemap={basemap} center={demoCenter} scale={demoScale} syncExtents={syncExtents}></Card>
+    <Card basemap={basemap} center={demoCenter} scale={demoScale}></Card>
 	{/each}
 
 	<h3 id="vector-basemaps">Vector Tile Basemaps</h3>
 
   <!-- another list of <Card> components containing one <EsriMapView> component -->
 	{#each vectorBasemaps as basemap}
-    <Card basemap={basemap} center={demoCenter} scale={demoScale} syncExtents={syncExtents}></Card>
+    <Card basemap={basemap} center={demoCenter} scale={demoScale}></Card>
   {/each}
 
-  <label>
-    <input type="checkbox" bind:checked={syncExtents} /> {syncExtentsLabel}
-  </label>
+  <SyncExtentsCheckbox />
 </main>
 
 <style>
@@ -163,11 +157,6 @@
 		content: "";
 		padding: 0;
 	}
-
-  label {
-    text-align: center;
-    cursor: pointer;
-  }
 
 	@media (max-width: 640px) {
 		main, nav {

--- a/src/Card.svelte
+++ b/src/Card.svelte
@@ -1,5 +1,5 @@
 <script>
-  // this <Card> component helps to organize:
+  // the <Card> component helps to organize:
   // - the basemap title
   // - an <EsriMapView> component instance
   // - and a link to help the user go back up
@@ -9,14 +9,13 @@
   export let basemap;
   export let center;
   export let scale;
-  export let syncExtents;
 </script>
 
 <div class="card">
   <p id={basemap} class="basemap-title">{basemap}</p>
 
   <div class="esri-map-view-wrapper">
-    <EsriMapView basemap={basemap} center={center} scale={scale} syncExtents={syncExtents}></EsriMapView>
+    <EsriMapView basemap={basemap} center={center} scale={scale}></EsriMapView>
   </div>
 
   <div class="top-link">

--- a/src/EsriMapView.svelte
+++ b/src/EsriMapView.svelte
@@ -5,8 +5,7 @@
 
   import { onMount } from 'svelte';
   import { loadModules } from 'esri-loader';
-  import { storeExtentInfo, storeSyncExtents } from './stores.js';
-  import { get } from 'svelte/store';
+  import { storeExtentInfo, storeSyncExtentsEnabled } from './stores.js';
 
   // props with default values in case none are passed in by a parent
   export let basemap = 'streets';
@@ -45,7 +44,7 @@
       center,
       scale,
       ui: {
-        // add the compass widget which is not standard for an Esri MapView
+        // add the compass widget which is not standard for a MapView
         components: ['attribution', 'zoom', 'compass']
       }
     });
@@ -54,11 +53,11 @@
     view.when(() => {
       let firstRun = true;
       watchUtils.whenTrue(view, 'stationary', newExtent => {
-        // Do not set the extent or rotation the first time the map loads:
+        // do not set the extent or rotation the first time the MapView loads
         if (firstRun) {
           firstRun = false;
         } else {
-          // Set the store with the extent and rotation
+          // set the store with the extent and rotation
           storeExtentInfo.set({
             extent: view.extent,
             rotation: view.rotation
@@ -67,9 +66,10 @@
       });
     });
 
-    // Every time the store is updated, update this map's extent and rotation to match what is in the store.
+    // every time the store is updated, set this MapView instance's extent
+    // and rotation to match what is in the store
     storeExtentInfo.subscribe(extentInfo => {
-      if (get(storeSyncExtents)) {
+      if ($storeSyncExtentsEnabled) {
         view.extent = extentInfo.extent;
         view.rotation = extentInfo.rotation;
       }
@@ -77,11 +77,10 @@
 
     // when the sync extents option is checked on again,
     // sync the MapView instances with the latest store information
-    storeSyncExtents.subscribe(syncExtents => {
-      if (syncExtents) {
-        const extentInfo = get(storeExtentInfo);
-        view.extent = extentInfo.extent;
-        view.rotation = extentInfo.rotation;
+    storeSyncExtentsEnabled.subscribe(syncExtentsEnabled => {
+      if (syncExtentsEnabled) {
+        view.extent = $storeExtentInfo.extent;
+        view.rotation = $storeExtentInfo.rotation;
       }
     });
   });

--- a/src/EsriMapView.svelte
+++ b/src/EsriMapView.svelte
@@ -1,25 +1,31 @@
 <script>
+  // the <EsriMapView> component:
+  // - creates a MapView instance with optional props (basemap, center, scale)
+  // - syncs extents and rotations among other MapView instances
+
   import { onMount } from 'svelte';
   import { loadModules } from 'esri-loader';
-  import { storeExtent } from './stores.js';
+  import { storeExtentInfo, storeSyncExtents } from './stores.js';
+  import { get } from 'svelte/store';
 
-  // props with default values
+  // props with default values in case none are passed in by a parent
   export let basemap = 'streets';
   export let center = [0, 0];
   export let scale = 295828763;
 
-  // this prop helps to optionally sync MapView extents
-  export let syncExtents;
+  // reference to the DOM node where this MapView instance will be created
+  // see "bind:this={viewContainer}" below
+  let viewContainer;
 
-  // reference to DOM node where the MapView will be created
-  let container;
-
+  // use "onMount" in the Svelte component lifecycle to create a MapView instance
   onMount(async () => {
+    // set Esri JSAPI options
     const options = {
       version: '4.14',
       css: true
     };
 
+    // load Esri JSAPI modules
     const [
       EsriMap,
       MapView,
@@ -30,42 +36,59 @@
       'esri/core/watchUtils'
     ], options);
 
+    // construct a MapView instance
     const view = new MapView({
-      container,
+      container: viewContainer,
       map: new EsriMap({
         basemap
       }),
       center,
       scale,
       ui: {
+        // add the compass widget which is not standard for an Esri MapView
         components: ['attribution', 'zoom', 'compass']
       }
     });
 
-    // the rest of this JS code only exists to optionally sync MapView extents
+    // the rest of this JS code only exists to optionally sync MapView instance extents and rotations
     view.when(() => {
       let firstRun = true;
-      watchUtils.whenTrue(view, "stationary", newExtent => {
-        // Do not set the extent the first time the map loads:
+      watchUtils.whenTrue(view, 'stationary', newExtent => {
+        // Do not set the extent or rotation the first time the map loads:
         if (firstRun) {
           firstRun = false;
         } else {
-          // Set the store with the extent
-          storeExtent.set(view.extent);
+          // Set the store with the extent and rotation
+          storeExtentInfo.set({
+            extent: view.extent,
+            rotation: view.rotation
+          });
         }
       });
     });
 
-    // Every time the store is updated, update this map's extent to match what is in the store.
-    storeExtent.subscribe(newExtent => {
-      if (syncExtents && newExtent) {
-        view.extent = newExtent;
+    // Every time the store is updated, update this map's extent and rotation to match what is in the store.
+    storeExtentInfo.subscribe(extentInfo => {
+      if (get(storeSyncExtents)) {
+        view.extent = extentInfo.extent;
+        view.rotation = extentInfo.rotation;
+      }
+    });
+
+    // when the sync extents option is checked on again,
+    // sync the MapView instances with the latest store information
+    storeSyncExtents.subscribe(syncExtents => {
+      if (syncExtents) {
+        const extentInfo = get(storeExtentInfo);
+        view.extent = extentInfo.extent;
+        view.rotation = extentInfo.rotation;
       }
     });
   });
+
 </script>
 
-<div bind:this={container}></div>
+<div bind:this={viewContainer}></div>
 
 <style>
   div {

--- a/src/SyncExtentsCheckbox.svelte
+++ b/src/SyncExtentsCheckbox.svelte
@@ -5,11 +5,11 @@
   // the same store is then used by <EsriMapView> children components
   // to know if they should sync their extents and rotations
 
-  import { storeSyncExtents } from './stores.js';
+  import { storeSyncExtentsEnabled } from './stores.js';
 </script>
 
 <label>
-  <input type="checkbox" bind:checked={$storeSyncExtents} />
+  <input type="checkbox" bind:checked={$storeSyncExtentsEnabled} />
   Sync Extent and Rotation?
 </label>
 

--- a/src/SyncExtentsCheckbox.svelte
+++ b/src/SyncExtentsCheckbox.svelte
@@ -1,0 +1,22 @@
+<script>
+  // the <SyncExtentsCheckbox> component optionally syncs MapView extents and rotations
+  // by binding a Boolean value from a store to a checkbox's "checked" attribute
+
+  // the same store is then used by <EsriMapView> children components
+  // to know if they should sync their extents and rotations
+
+  import { storeSyncExtents } from './stores.js';
+</script>
+
+<label>
+  <input type="checkbox" bind:checked={$storeSyncExtents} />
+  Sync Extent and Rotation?
+</label>
+
+<style>
+  label {
+    text-align: center;
+    cursor: pointer;
+    background-color: #f4f4f4;
+  }
+</style>

--- a/src/main.js
+++ b/src/main.js
@@ -2,9 +2,14 @@ import App from './App.svelte';
 
 const app = new App({
 	target: document.body,
-	props: {
+  props: {
+    // configurable title and subtitle for HTML display
     title: 'Esri Svelte Example',
-    subtitle: 'Explore Esri\'s Basemaps'
+    subtitle: 'Explore Esri\'s Basemaps',
+
+    // configurable Esri MapView initial center and scale values
+    demoCenter: [-59.5, -51.85], // Islas Malvinas / Falkland Islands
+    demoScale: 4622324
 	}
 });
 

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,0 +1,4 @@
+// https://svelte.dev/tutorial/writable-stores
+import { writable } from "svelte/store";
+
+export const storeExtent = writable(false);

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,4 +1,9 @@
 // https://svelte.dev/tutorial/writable-stores
 import { writable } from "svelte/store";
 
-export const storeExtent = writable(false);
+export const storeExtentInfo = writable({
+  extent: null,
+  rotation: null
+});
+
+export const storeSyncExtents = writable(true);

--- a/src/stores.js
+++ b/src/stores.js
@@ -1,4 +1,6 @@
 // https://svelte.dev/tutorial/writable-stores
+// https://svelte.dev/docs#writable
+
 import { writable } from "svelte/store";
 
 export const storeExtentInfo = writable({
@@ -6,4 +8,4 @@ export const storeExtentInfo = writable({
   rotation: null
 });
 
-export const storeSyncExtents = writable(true);
+export const storeSyncExtentsEnabled = writable(true);


### PR DESCRIPTION
Adds to @gavinr's awesome svelte store improvements in PR #1.

@gavinr your review of the `storeSyncExtents` Boolean now being in a separate store (and unique checkbox component) while also adding the syncing of MapView `rotation` would be greatly appreciated. Thanks!